### PR TITLE
fix: make compatible with `release-it@15`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
-const path = require("path");
-const Plugin = require("release-it/lib/plugin/Plugin.js");
-const packageJson = require(path.join(process.cwd(), "./package.json"));
+import fs from "node:fs";
+import path from "node:path";
+import { Plugin } from "release-it";
 
-module.exports = class CustomVersion extends Plugin {
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), "./package.json")).toString()
+);
+
+export default class CustomVersion extends Plugin {
   static disablePlugin() {
     const depVersion = getDepVersion();
     const currentPackageVersion = packageJson.version;
@@ -19,7 +23,7 @@ module.exports = class CustomVersion extends Plugin {
   getIncrementedVersionCI() {
     return getDepVersion();
   }
-};
+}
 
 function getDepName() {
   if (!packageJson.name) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "release-it-plugin-esm-bundle",
   "version": "2.1.0",
   "description": "",
-  "main": "index.js",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  },
   "scripts": {
     "format": "yarn prettier --write './**/*'"
   },
@@ -21,7 +24,9 @@
     "url": "https://github.com/esm-bundle/release-it-plugin-esm-bundle/issues"
   },
   "homepage": "https://github.com/esm-bundle/release-it-plugin-esm-bundle#readme",
-  "dependencies": {},
+  "peerDependencies": {
+    "release-it": ">=15.0.0"
+  },
   "devDependencies": {
     "husky": "^4.2.5",
     "prettier": "^2.0.5",


### PR DESCRIPTION
The publish job is failing in all repos with the error:
```
ERROR Package subpath './lib/plugin/Plugin.js' is not defined by "exports"
```

https://github.com/release-it/release-it/blob/master/CHANGELOG.md#v15-2022-04-30